### PR TITLE
Fix scan Subdomains.

### DIFF
--- a/example/scanDomain.ts
+++ b/example/scanDomain.ts
@@ -4,9 +4,13 @@ async function main() {
 
     const urls=[
         "https://sui.io",
+        "deepbook.tech",
         "https://app.cetus.zone/swap",
+        "https://a1.b2.deepbook.cetus.zone",
+        "https://deepbook.cetus.zone/v2",
         "https://scam-cetus.zone/swap",//block
         "https://scam.scam-cetus.zone/swap",//block
+        "https://scam1.scam2.scam-cetus.zone/swap",//block
         "https://500-airdrop.top",//block
     ]
     const blocklist = new SuiSecBlocklist();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,13 +78,25 @@ export async function fetchDomainBlocklist(
 }
 
 export function scanDomain(blocklist: string[], url: string): Action {
-  const domain = new URL(url).hostname.toLowerCase();
+  // parse domain of https://example.com or http://example.com  or example.com , then domain is example.com
+  const domain = url.startsWith("http")? new URL(url).hostname.toLowerCase(): url.toLowerCase();
   const domainParts = domain.split(".");
 
   for (let i = 0; i < domainParts.length - 1; i++) {
     const domainToLookup = domainParts.slice(i).join(".");
     if (blocklist.includes(domainToLookup)) {
       return Action.BLOCK;
+    }
+  }
+
+  for (const key in domainMap) {
+    let whitelistDomain = domainMap[key].toLowerCase();
+    let whitelistDomainParts = whitelistDomain.split(".");
+
+    let slice = domainParts.slice(-whitelistDomainParts.length);
+    //https://deepbook.cetus.zone is NOT-BLOCK
+    if(slice.join('.') === whitelistDomain){
+      return Action.NONE;
     }
   }
 


### PR DESCRIPTION
test code
   ```
 const urls=[
        "https://sui.io",
        "deepbook.tech",
        "https://app.cetus.zone/swap",
        "https://a1.b2.deepbook.cetus.zone",
        "https://deepbook.cetus.zone/v2",
        "https://scam-cetus.zone/swap",//block
        "https://scam.scam-cetus.zone/swap",//block
        "https://scam1.scam2.scam-cetus.zone/swap",//block
        "https://500-airdrop.top",//block
    ]
    const blocklist = new SuiSecBlocklist();
    await blocklist.fetchDomainlist();
    for (let url of urls) {
        let action = await blocklist.scanDomain(url);
        console.log(`${url} ${action}`);
    }
```